### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "urls": [
+    ["schedule/__init__.py", "github:rguillon/schedule/schedule/__init__.py"],
+  ],
+  "deps": [
+    ["ucontextlib", "latest"],
+    ["logging", "latest"],
+    ["time", "latest"]
+  ],
+  "version": "0.3.2"
+}


### PR DESCRIPTION
To allow easy install using `mip`: 
https://docs.micropython.org/en/latest/reference/packages.html

```
>>> import mip
>>> mip.install('github:rguillon/schedule')
Installing github:rguillon/schedule/package.json to /lib
Copying: /lib/schedule/__init__.py
Installing ucontextlib (latest) from https://micropython.org/pi/v2 to /lib
Exists: /lib/ucontextlib.mpy
Installing logging (latest) from https://micropython.org/pi/v2 to /lib
Exists: /lib/logging.mpy
Installing time (latest) from https://micropython.org/pi/v2 to /lib
Copying: /lib/time.mpy
Done
```

